### PR TITLE
Build the package kmod-isci for CentOS Stream 9

### DIFF
--- a/kmod-isci/osg/kmod-isci.spec
+++ b/kmod-isci/osg/kmod-isci.spec
@@ -1,14 +1,17 @@
 # Define the kmod package name here.
 %define kmod_name	isci
 
-# If kmod_kernel_version isn't defined on the rpmbuild line, define it here.
-%{!?kmod_kernel_version: %define kmod_kernel_version 5.14.0-427.13.1.el9_4}
-
 %{!?dist: %define dist .el9}
+
+%define kernel_version 5.14.0
+%define kernel_abi_number 467
+
+%define kmod_kernel_version %{kernel_version}-%{kernel_abi_number}%{?dist}
+
 
 Name:		kmod-%{kmod_name}
 Version:	1.2.0
-Release:	7%{?dist}
+Release:	7.%{kernel_version}.%{kernel_abi_number}%{?dist}
 Summary:	%{kmod_name} kernel module(s)
 Group:		System Environment/Kernel
 License:	GPLv2

--- a/kmod-isci/osg/kmod-isci.spec
+++ b/kmod-isci/osg/kmod-isci.spec
@@ -1,0 +1,211 @@
+# Define the kmod package name here.
+%define kmod_name	isci
+
+# If kmod_kernel_version isn't defined on the rpmbuild line, define it here.
+%{!?kmod_kernel_version: %define kmod_kernel_version 5.14.0-427.13.1.el9_4}
+
+%{!?dist: %define dist .el9}
+
+Name:		kmod-%{kmod_name}
+Version:	1.2.0
+Release:	7%{?dist}
+Summary:	%{kmod_name} kernel module(s)
+Group:		System Environment/Kernel
+License:	GPLv2
+URL:		http://www.kernel.org/
+
+# Sources.
+Source0:	%{kmod_name}-%{version}.tar.gz
+Source5:	GPL-v2.0.txt
+
+%define __spec_install_post \
+		/usr/lib/rpm/check-buildroot \
+		/usr/lib/rpm/redhat/brp-ldconfig \
+		/usr/lib/rpm/brp-compress \
+		/usr/lib/rpm/brp-strip-comment-note /usr/bin/strip /usr/bin/objdump \
+		/usr/lib/rpm/brp-strip-static-archive /usr/bin/strip \
+		/usr/lib/rpm/redhat/brp-python-bytecompile "" "1" "0" \
+		/usr/lib/rpm/brp-python-hardlink \
+		/usr/lib/rpm/redhat/brp-mangle-shebangs
+%define findpat %( echo "%""P" )
+%define __find_requires /usr/lib/rpm/redhat/find-requires.ksyms
+%define __find_provides /usr/lib/rpm/redhat/find-provides.ksyms %{kmod_name} %{?epoch:%{epoch}:}%{version}-%{release}
+%define dup_state_dir %{_localstatedir}/lib/rpm-state/kmod-dups
+%define kver_state_dir %{dup_state_dir}/kver
+%define kver_state_file %{kver_state_dir}/%{kmod_kernel_version}.%{_arch}
+%define dup_module_list %{dup_state_dir}/rpm-kmod-%{kmod_name}-modules
+%define debug_package %{nil}
+
+%global _use_internal_dependency_generator 0
+%global kernel_source() %{_usrsrc}/kernels/%{kmod_kernel_version}.%{_arch}
+
+BuildRoot:			%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+
+ExclusiveArch:		x86_64
+
+BuildRequires:		elfutils-libelf-devel
+BuildRequires:		kernel-abi-stablelists
+BuildRequires:		kernel-devel = %{kmod_kernel_version}
+BuildRequires:		kernel-rpm-macros
+BuildRequires:		redhat-rpm-config
+BuildRequires:		rpm-build
+BuildRequires:		gcc
+BuildRequires:		make
+
+Provides:			kernel-modules >= %{kmod_kernel_version}.%{_arch}
+Provides:			kmod-%{kmod_name} = %{?epoch:%{epoch}:}%{version}-%{release}
+
+Requires:			kernel >= %{kmod_kernel_version}
+Requires:			kernel-core-uname-r >= %{kmod_kernel_version}
+
+Requires(post):		%{_sbindir}/depmod
+Requires(postun):	%{_sbindir}/depmod
+Requires(post):		%{_sbindir}/weak-modules
+Requires(postun):	%{_sbindir}/weak-modules
+
+%description
+This package provides the %{kmod_name} kernel module(s).
+It is built to depend upon the specific ABI provided by a range of releases
+of the same variant of the Linux kernel and not on any one specific build.
+
+%prep
+%setup -q -n %{kmod_name}-%{version}
+echo "override %{kmod_name} * weak-updates/%{kmod_name}" > kmod-%{kmod_name}.conf
+
+%build
+%{__make} -C %{kernel_source} %{?_smp_mflags} V=1 modules M=$PWD
+
+whitelist="/lib/modules/kabi-current/kabi_stablelist_%{_target_cpu}"
+for modules in $( find . -name "*.ko" -type f -printf "%{findpat}\n" | sed 's|\.ko$||' | sort -u ) ; do
+	# update greylist
+	nm -u ./$modules.ko | sed 's/.*U //' |  sed 's/^\.//' | sort -u | while read -r symbol; do
+		grep -q "^\s*$symbol\$" $whitelist || echo "$symbol" >> ./greylist
+	done
+done
+sort -u greylist | uniq > greylist.txt
+
+%install
+%{__install} -d %{buildroot}/lib/modules/%{kmod_kernel_version}.%{_arch}/extra/%{kmod_name}/
+%{__install} %{kmod_name}.ko %{buildroot}/lib/modules/%{kmod_kernel_version}.%{_arch}/extra/%{kmod_name}/
+%{__install} -d %{buildroot}%{_sysconfdir}/depmod.d/
+%{__install} -m 0644 kmod-%{kmod_name}.conf %{buildroot}%{_sysconfdir}/depmod.d/
+%{__install} -d %{buildroot}%{_defaultdocdir}/kmod-%{kmod_name}-%{version}/
+%{__install} -m 0644 %{SOURCE5} %{buildroot}%{_defaultdocdir}/kmod-%{kmod_name}-%{version}/
+%{__install} -m 0644 greylist.txt %{buildroot}%{_defaultdocdir}/kmod-%{kmod_name}-%{version}/
+
+# strip the modules(s)
+find %{buildroot} -name \*.ko -type f | xargs --no-run-if-empty %{__strip} --strip-debug
+
+# Sign the modules(s)
+%if %{?_with_modsign:1}%{!?_with_modsign:0}
+	# If the module signing keys are not defined, define them here.
+	%{!?privkey: %define privkey %{_sysconfdir}/pki/SECURE-BOOT-KEY.priv}
+	%{!?pubkey: %define pubkey %{_sysconfdir}/pki/SECURE-BOOT-KEY.der}
+	for module in $(find %{buildroot} -type f -name \*.ko);
+		do %{_usrsrc}/kernels/%{kmod_kernel_version}.%{_arch}/scripts/sign-file \
+			sha256 %{privkey} %{pubkey} $module;
+	done
+%endif
+
+%clean
+%{__rm} -rf %{buildroot}
+
+%post
+modules=( $(find /lib/modules/%{kmod_kernel_version}.x86_64/extra/%{kmod_name} | grep '\.ko$') )
+printf '%s\n' "${modules[@]}" | %{_sbindir}/weak-modules --add-modules --no-initramfs
+
+mkdir -p "%{kver_state_dir}"
+touch "%{kver_state_file}"
+
+exit 0
+
+%posttrans
+# We have to re-implement part of weak-modules here because it doesn't allow
+# calling initramfs regeneration separately
+if [ -f "%{kver_state_file}" ]; then
+        kver_base="%{kmod_kernel_version}"
+        kvers=$(ls -d "/lib/modules/${kver_base%%.*}"*)
+
+        for k_dir in $kvers; do
+                k="${k_dir#/lib/modules/}"
+
+                tmp_initramfs="/boot/initramfs-$k.tmp"
+                dst_initramfs="/boot/initramfs-$k.img"
+
+                # The same check as in weak-modules: we assume that the kernel present
+                # if the symvers file exists.
+                if [ -e "/$k_dir/symvers.gz" ]; then
+                        /usr/bin/dracut -f "$tmp_initramfs" "$k" || exit 1
+                        cmp -s "$tmp_initramfs" "$dst_initramfs"
+                        if [ "$?" = 1 ]; then
+                                mv "$tmp_initramfs" "$dst_initramfs"
+                        else
+                                rm -f "$tmp_initramfs"
+                        fi
+                fi
+        done
+
+        rm -f "%{kver_state_file}"
+        rmdir "%{kver_state_dir}" 2> /dev/null
+fi
+
+rmdir "%{dup_state_dir}" 2> /dev/null
+
+exit 0
+
+%preun
+if rpm -q --filetriggers kmod 2> /dev/null| grep -q "Trigger for weak-modules call on kmod removal"; then
+        mkdir -p "%{kver_state_dir}"
+        touch "%{kver_state_file}"
+fi
+
+mkdir -p "%{dup_state_dir}"
+rpm -ql kmod-%{kmod_name}-%{version}-%{release}.%{_arch} | grep '\.ko$' > "%{dup_module_list}"
+
+%postun
+if rpm -q --filetriggers kmod 2> /dev/null| grep -q "Trigger for weak-modules call on kmod removal"; then
+        initramfs_opt="--no-initramfs"
+else
+        initramfs_opt=""
+fi
+
+modules=( $(cat "%{dup_module_list}") )
+rm -f "%{dup_module_list}"
+printf '%s\n' "${modules[@]}" | %{_sbindir}/weak-modules --remove-modules $initramfs_opt
+
+rmdir "%{dup_state_dir}" 2> /dev/null
+
+exit 0
+
+%files
+%defattr(644,root,root,755)
+/lib/modules/%{kmod_kernel_version}.%{_arch}/
+%config /etc/depmod.d/kmod-%{kmod_name}.conf
+%doc /usr/share/doc/kmod-%{kmod_name}-%{version}/
+
+%changelog
+* Fri May 03 2024 Tuan Hoang <tqhoang@elrepo.org> - 1.2.0-7
+- Rebuilt against 9.4 GA kernel 5.14.0-427.13.1.el9_4
+- Source code unchanged from 9.3 GA kernel
+
+* Sat Jan 27 2024 Philip J Perry <phil@elrepo.org> - 1.2.0-6
+- Rebuilt against kernel 5.14.0-362.18.1.el9_3
+
+* Fri Dec 15 2023 Tuan Hoang <tqhoang@elrepo.org> - 1.2.0-5
+- Rebuilt against RHEL 9.3 errata kernel 5.14.0-362.13.1.el9_3
+
+* Tue Nov 07 2023 Philip J Perry <phil@elrepo.org> - 1.2.0-4
+- Rebuilt for RHEL 9.3
+- Source updated from RHEL 9.3 kernel
+
+* Tue May 09 2023 Philip J Perry <phil@elrepo.org> - 1.2.0-3
+- Rebuilt for RHEL 9.2 
+- Source updated from RHEL 9.2 kernel
+
+* Tue Nov 15 2022 Philip J Perry <phil@elrepo.org> - 1.2.0-2
+- Rebuilt for RHEL 9.1
+- Source updated from RHEL 9.1 kernel
+
+* Tue May 17 2022 Philip J Perry <phil@elrepo.org> - 1.2.0-1
+- Initial build for RHEL 9
+- Backported from kernel-5.14.0-70.13.1.el9_0

--- a/kmod-isci/upstream/elrepo.source
+++ b/kmod-isci/upstream/elrepo.source
@@ -1,0 +1,1 @@
+http://mirror.rc.usf.edu/elrepo/archive/elrepo/el9/SRPMS/kmod-isci-1.2.0-7.el9_4.elrepo.src.rpm sha1sum=2785e62e1caa3177dca1da4259bc119d8482af8b


### PR DESCRIPTION
This adds the package `kmod-isci` originally built for EL 9 from [ELRepo](https://github.com/elrepo/packages/tree/master/isci-kmod/el9). A patch is applied to encode the kernel ABI number into the release of the NVR of the RPM, accommodating the rapid update cycle of CentOS Stream 9's kernel.